### PR TITLE
typo: at line 221, 173 , 293 and 307

### DIFF
--- a/Assignments/Assignment-typo.md
+++ b/Assignments/Assignment-typo.md
@@ -170,7 +170,7 @@ X.org 6.8.1 mouse cursor on Fooware MV1005 vid. chipset - is misshapen
 
 The process of writing an "object-deviation" description will help you organize your thinking about the problem in more detail. What is affected? Just the mouse cursor or other graphics too? Is this specific to the X.org version of X? To version 6.8.1? Is this specific to Fooware video chipsets? To model MV1005? A hacker who sees the result can immediately understand what it is that you are having a problem with *and* the problem you are having, at a glance.
 
-More generally, imagine looking at the index of an archive of questions, with just the subject lines showing. Make your subject line reflect your question well enough that the next person searching the archive with a question simi lar to yours will be able to follow the thread to an answer rather than posting the question again.
+More generally, imagine looking at the index of an archive of questions, with just the subject lines showing. Make your subject line reflect your question well enough that the next person searching the archive with a question similar to yours will be able to follow the thread to an answer rather than posting the question again.
 
 If you ask a question in a reply, be sure to change the subject line to indicate that you're asking a question. A Subject line that looks like "Re: test" or "Re: new bug" is less likely to attract useful amounts of attention. Also, pare quotation of previous messages to the minimum consistent with cluing in new readers.
 


### PR DESCRIPTION
fix https://github.com/X-lab2017/oss101/issues/71
- fix Extra spaces  typo 'simi lar' at line 173 to 'similar'
- fix skip spaces typo 'yousaw' at line 221 to 'you saw'
- fix extra letter typo 'figguring' at line 293 to 'figuring'
- fix skip spaces typo 'takea' at  line 307 to 'take a'

小组成员学号：51255903098、51255903056、51255903047