### PR TITLE
typo: eaier at line 441, threten at line 431, clams at line 435

### DIFF
--- a/Assignments/Assignment-typo.md
+++ b/Assignments/Assignment-typo.md
@@ -438,7 +438,7 @@ There have been hacker forums where, out of some misguided sense of hyper-courte
 
 Exaggeratedly "friendly" (in that feshion) or useful: Pick one.
 
-Remember: When that hacker tells you that you've screwed up, and (no matter how gruffly) tells you not to do it again, he's acting out of concern for (1) you and (2) his community. It would be much eaier for him to ignore you and filter you out of his life. If you can't manage to be grateful, at least have a little dignity, don't whine, and don't expect to be treated like a fragile doll just because you're a newcomer with a theatrically hypersensitive soul and delusions of entitlement.
+Remember: When that hacker tells you that you've screwed up, and (no matter how gruffly) tells you not to do it again, he's acting out of concern for (1) you and (2) his community. It would be much easier for him to ignore you and filter you out of his life. If you can't manage to be grateful, at least have a little dignity, don't whine, and don't expect to be treated like a fragile doll just because you're a newcomer with a theatrically hypersensitive soul and delusions of entitlement.
 
 Sometimes people will attack you personally, flame without an apparent reason, etc., even if you don't screw up (or have only screwed up in their imgination). In this case, complaining is the way to *really* screw up.
 


### PR DESCRIPTION
fix https://github.com/X-lab2017/oss101/issues/71

- fix wrong letter typo `eaier` at line 441 to `easier`

- fix wrong letter typo `threten` at line 431 to `threaten`



- fix wrong letter typo `clams` at line 435 to `claims`

team: 51255903038 51255903017 51255903040