### PR TITLE
typo: `ananswer` at line 351, `ignwored` at line 77，`andthe` at line 143

### DIFF
--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -74,7 +74,7 @@ On the other hand, making it clear that you are able and willing to help in the 
 
 ### Choose your forum carefully
 
-Be sensitive in choosing where you ask your question. You are likely to be ignwored, or written off as a loser, if you:
+Be sensitive in choosing where you ask your question. You are likely to be ignored, or written off as a loser, if you:
 
 - post your question to a forum where it's off topic
 

--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -348,7 +348,7 @@ If you suspect you have been passed a homework question, but can't solve it anyw
 
 ### Prune pointless queries
 
-Resist the temptation to close your request for help with semantically-null questions like "Can anyone help me?" or "Is there ananswer?" First: if you've written your problem description halfway competently, such tacked-on questions are at best superfluous. Second: because they are superfluous, hackers find them annoying --- and are likely to return logically impeccable but dismissive answers like "Yes, you can be helped" and "No, there is no help for you."
+Resist the temptation to close your request for help with semantically-null questions like "Can anyone help me?" or "Is there an answer?" First: if you've written your problem description halfway competently, such tacked-on questions are at best superfluous. Second: because they are superfluous, hackers find them annoying --- and are likely to return logically impeccable but dismissive answers like "Yes, you can be helped" and "No, there is no help for you."
 
 In general, asking yes-or-no questions is a good thing to avoid unless you want a [yes-or-no answer](http://homepage.ntlworld.com./jonathan.deboynepollard/FGA/questions-with-yes-or-no-answers.html).
 

--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -140,7 +140,7 @@ When a project has a development mailing list, write to the mailing list, not to
 
   - Asking questions on the list distributes load among developers. The individual developer (especially if he's the project leader) may be too busy to answer your quertions.
 
-  - Most mailing lists are archived and the archives are indexed by search engines. If you ask your question on-list and it is answered, a future querent could find your question andthe answer on the Web instead of asking it again.
+  - Most mailing lists are archived and the archives are indexed by search engines. If you ask your question on-list and it is answered, a future querent could find your question and the answer on the Web instead of asking it again.
 
   - If certain questions are seen to be asked often, developers can use that information to improve the documentation or the software itself to be less confusing. But if those questions are asked in private, nobody has the complete picture of what questions are asked most often.
 


### PR DESCRIPTION
fixes #143

- fix skip spaces typo `ananswer` at line 351 to `an answer` @gloriaaa0312
- fix extra letter typo `ignwored` at line 77 to `ignored` @XuDashuai0827
- fix skip spaces typo `andthe` at line 143 to `and the` @wsy1114534906

team: 10205501409 10205501437 10205501450 10205501429