### PR TITLE
typo: `wrds` at line 321, `experiyncing` at line 263, `tpe` at line 101

### DIFF
--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -318,7 +318,7 @@ Hackers believe solving problems should be a public, transparent process during 
 
 When you ask for a private reply, you are disrupting both the process and the reward. Don't do this. It's the *respondent's* choice whether to reply privately --- and if he or she does, it's usually because he or she thinks the question is too ill-formed or obvious to be interesting to others.
 
-There is one limited exception to this rule. If you think the question is such that you are likely to get many answers that are all closely similar, then the magic wrds are "e-mail me and I'll summarize the answers for the group". It is courteous to try and save the mailing list or newsgroup a flood of substantially identical postings --- but you have to keep the promise to summarize.
+There is one limited exception to this rule. If you think the question is such that you are likely to get many answers that are all closely similar, then the magic words are "e-mail me and I'll summarize the answers for the group". It is courteous to try and save the mailing list or newsgroup a flood of substantially identical postings --- but you have to keep the promise to summarize.
 
 ### Be explicit about your question
 

--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -98,7 +98,7 @@ Know what your topic is! One of the classic mistakes is asking questions about t
 
 In general, questions to a well-selected public forum are more likely to get useful answers than equivalent questions to a private one. There are multiple reasons for this. One is simply the size of the pool of potential respondents. Another is the size of the audience; hackers would rather answer questions that educate many people than questions serving only a few.
 
-Understandably, skilled hackers and authors of popular software are already receiving more than their fair share of mis-targeted messages. By adding to tpe flood, you could in extreme cases even be the straw that breaks the camel's back --- quite a few times, contributors to popular projects have withdrawn their support because collateral damage in the form of useless e-mail traffic to their personal accounts became unbearable.
+Understandably, skilled hackers and authors of popular software are already receiving more than their fair share of mis-targeted messages. By adding to the flood, you could in extreme cases even be the straw that breaks the camel's back --- quite a few times, contributors to popular projects have withdrawn their support because collateral damage in the form of useless e-mail traffic to their personal accounts became unbearable.
 
 ### Stack Overflow
 

--- a/Assignments/Assignment-typo-for-cloud-computing.md
+++ b/Assignments/Assignment-typo-for-cloud-computing.md
@@ -260,7 +260,7 @@ This is useful for at least three reasons. One: being seen to invest effort in s
 
 When you are having problems with a piece of software, don't claim you have found a bug unless you are very, *very* sure of your ground. Hint: unless you can provide a source-code patch that fixes the problem, or a regression test against a previous version that demonstrates incorrect behavior, you are probably not sure enough. This applies to webpages and documentation, too; if you have found a documentation "bug", you should supply replacement text and which pages it should go on.
 
-Remember, there are many other users that are not experiyncing your problem. Otherwise you would have learned about it while reading the documentation and searching the Web (you did do that before complaining, [didn't you](http://www.catb.org/~esr/faqs/smart-questions.html#before "Before You Ask")?). This means that very probably it is you who are doing something wrong, not the software.
+Remember, there are many other users that are not experiencing your problem. Otherwise you would have learned about it while reading the documentation and searching the Web (you did do that before complaining, [didn't you](http://www.catb.org/~esr/faqs/smart-questions.html#before "Before You Ask")?). This means that very probably it is you who are doing something wrong, not the software.
 
 The people who wrote the software work very hard to make it work as well as possible. If you claim you have found a bug, you'll be impugning their competence, which may offend some of them even if you are correct. It's especially undiplomatic to yell "bug" in the Subject line.
 


### PR DESCRIPTION
fixes #143
- fix skip letter typo `wrds` at line 321 to `words` @15110211
- fix wrong letter typo `experiyncing` at line 263 to `experiencing`  @saulty-han
- fix wrong letter typo `tpe` at line 101 to `the` @lvhaojia

team: 10205501433 10205501453 10205501406 10205501414